### PR TITLE
Added support for the standard day period type.

### DIFF
--- a/html/js/datetime.js
+++ b/html/js/datetime.js
@@ -35,7 +35,8 @@
         'hour': 'Hours',
         'minute': 'Minutes',
         'second': 'Seconds',
-        'dayperiod': 'Hours'
+        'dayperiod': 'Hours',
+        'dayPeriod': 'Hours'
     };
 
     var FORMAT = {
@@ -389,7 +390,7 @@
             var fnName = (this.props.useUTC ? 'UTC' : '') + hashTypeFn[type],
                 newValue = proxyTime['get' + fnName]();
 
-            if (part.type === 'dayperiod') {
+            if (part.type === 'dayperiod' || part.type === 'dayPeriod') {
                 newValue += operator * 12;
             } else if (part.type === 'weekday') {
                 newValue += operator;


### PR DESCRIPTION
Chrome has a bug - it returns the type as dayperiod instead of dayPeriod and this is probably going to change. Support both of the strings for now.